### PR TITLE
FIX: b03112 PCB Revision and Release Date

### DIFF
--- a/raspi-boards.txt
+++ b/raspi-boards.txt
@@ -88,7 +88,7 @@ a220a0	Q1 2021	Compute Module 1.0	1 GB	(Mfg by Embest)
 a32082	Q4 2016	3 Model B	1.2	1 GB	(Mfg by Sony Japan)
 a52082	3B 2016?  3 Model B 1.2 1GB Stadium
 b03111	Q2 2019	4 Model B	1.1	2 GB	(Mfg by Sony UK)
-b03112	Q4 2020	4 Model B	1.1	2 GB	(Mfg by Sony UK)
+b03112	Q4 2020	4 Model B	1.2	2 GB	(Mfg by Sony UK)
 b03114	Q4 2020	4 Model B	1.4	2 GB	(Mfg by Sony UK)
 c03111	Q2 2019	4 Model B	1.1	4 GB	(Mfg by Sony UK)
 c03112	Q4 2020	4 Model B	1.2	4 GB	(Mfg by Sony UK)

--- a/raspi-boards.txt
+++ b/raspi-boards.txt
@@ -1,7 +1,8 @@
 #--------><--------><--------><--------><--------><--------><--------><-------->
 # Author           : OneOfTheInfinteMonkeys
-# Revision         : 1.8
-# Date             : 11 Nov 2021
+# Contributor      : Max Peal
+# Revision         : 1.9
+# Date             : 12 Jan 2022
 # Licence          : Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
 #------------------:
 # Comments         :
@@ -16,6 +17,9 @@
 #                  :
 #------------------:
 # Revisions        :
+#                  :
+#                  : 1.9
+#                  : Fix for b03112 fix PCB Revision, data form http://elinux.org/RPi_HardwareHistory
 #                  :
 #                  : 1.8
 #                  : Added additional boards from www.raspberrypi.com
@@ -88,7 +92,7 @@ a220a0	Q1 2021	Compute Module 1.0	1 GB	(Mfg by Embest)
 a32082	Q4 2016	3 Model B	1.2	1 GB	(Mfg by Sony Japan)
 a52082	3B 2016?  3 Model B 1.2 1GB Stadium
 b03111	Q2 2019	4 Model B	1.1	2 GB	(Mfg by Sony UK)
-b03112	Q4 2020	4 Model B	1.2	2 GB	(Mfg by Sony UK)
+b03112	Q2 2019	4 Model B	1.2	2 GB	(Mfg by Sony UK)
 b03114	Q4 2020	4 Model B	1.4	2 GB	(Mfg by Sony UK)
 c03111	Q2 2019	4 Model B	1.1	4 GB	(Mfg by Sony UK)
 c03112	Q4 2020	4 Model B	1.2	4 GB	(Mfg by Sony UK)


### PR DESCRIPTION
FIX: b03112 PCB Revision and Release Date
accounting to https://elinux.org/RPi_HardwareHistory
fixes #4 